### PR TITLE
Fix for when sanitizer removes user.email

### DIFF
--- a/server/services/passwordless.js
+++ b/server/services/passwordless.js
@@ -163,7 +163,11 @@ module.exports = (
       if (!user) {
         return user;
       }
-      return await sanitize.sanitizers.defaultSanitizeOutput(userSchema, user);
+      let sanitizedUser = await sanitize.sanitizers.defaultSanitizeOutput(userSchema, user);
+      if(!sanitizedUser.email && user.email){
+        sanitizedUser.email = user.email
+      }
+      return sanitizedUser
     },
 
     template(layout, data) {


### PR DESCRIPTION
This sanitizer removes the user.email:
https://github.com/kucherenko/strapi-plugin-passwordless/blob/main/server/services/passwordless.js#L166

and because email is null, this check fails:
https://github.com/kucherenko/strapi-plugin-passwordless/blob/main/server/controllers/auth.js#L107

https://github.com/kucherenko/strapi-plugin-passwordless/issues/5#issuecomment-1182297456

I don't know the cause, but the sanitizer could have been modified somewhere else in Strapi (maybe another plugin?). 
That change will ensure the email is always returned

just saw on the readme pull requests are welcome, so here you go!