### PR TITLE
Add await to createToken

### DIFF
--- a/server/services/passwordless.js
+++ b/server/services/passwordless.js
@@ -122,15 +122,14 @@ module.exports = (
     async createToken(email, context) {
       const settings = await this.settings();
       const {token_length = 20} = settings;
-      const tokensService = strapi.query('plugin::passwordless.token');
-      tokensService.update({where: {email}, data: {is_active: false}});
+      await strapi.query('plugin::passwordless.token').update({where: {email}, data: {is_active: false}});
       const body = nanoid(token_length);
       const tokenInfo = {
         email,
         body,
         context: JSON.stringify(context)
       };
-      return tokensService.create({data: tokenInfo});
+      return strapi.query('plugin::passwordless.token').create({data: tokenInfo});
     },
 
     updateTokenOnLogin(token) {


### PR DESCRIPTION
Currently there is no 'await' when updating previously stored tokens. So when a user signs up for the first time, sometimes, the `create()` function can run before `update()`, as we don't wait for update to finish.

That can result in the new token being invalidated by getting set to `is_active:false` almost immediately. That's why sometimes when you request a token, it's already invalid, and you have to request a new one.

Adding `await` to the update fixes that issue for me!