### PR TITLE
feat(documentation): add openapi spec

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@
 const services = require("./services");
 const routes = require("./routes");
 const policies = require("./policies");
+const register = require("./register");
 const controllers = require("./controllers");
 const contentTypes = require("./content-types");
 const bootstrap = require("./bootstrap");
@@ -12,6 +13,7 @@ module.exports = {
   contentTypes,
   controllers,
   policies,
+  register,
   routes,
   services
 };

--- a/server/register.js
+++ b/server/register.js
@@ -1,0 +1,17 @@
+//
+
+const documentation = require("../documentation/1.0.0/passwordless.json");
+
+//
+
+module.exports = ({ strapi }) => {
+  if (strapi.plugin("documentation")) {
+    strapi
+      .plugin("documentation")
+      .service("override")
+      .registerOverride(documentation, {
+        pluginOrigin: "passwordless",
+        excludeFromGeneration: ["passwordless"],
+      });
+  }
+};


### PR DESCRIPTION
This override is adding the endpoints to the openapi spec file.
Inspired by : 
- https://github.com/strapi/strapi/blob/v4.10.5/packages/core/upload/server/register.js#L27-L34
- https://github.com/strapi/strapi/blob/v4.10.5/packages/plugins/users-permissions/server/register.js#L17-L28

![image](https://github.com/kucherenko/strapi-plugin-passwordless/assets/730511/137444be-aa29-49e3-aae9-af5f5599e6bb)

