### PR TITLE
fix(documentation): display missing Passwordless-SendLinkRequest schema

### DIFF
--- a/documentation/1.0.0/passwordless.yaml
+++ b/documentation/1.0.0/passwordless.yaml
@@ -42,14 +42,17 @@ paths:
         - Passwordless
       summary: Send an email to user with login link
       requestBody:
-        $ref: "#/components/requestBodies/Passwordless-SendLinkRequest"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Passwordless-SendLinkRequest"
       responses:
         200:
           description: Returns email and boolean to confirm email was sent
           content:
             application/json:
               schema:
-                $ref: "#/components/requestBodies/Passwordless-EmailSent"
+                $ref: "#/components/schemas/Passwordless-EmailSent"
         400:
           description: Bad Request
           content:
@@ -85,26 +88,20 @@ components:
             context:
               type: object
 
-  requestBodies:
     Passwordless-SendLinkRequest:
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              email:
-                description: the user email
-                required: true
-                type: string
-              username:
-                description: username for new user
-                type: string
-              context:
-                description: context of authentification
-                type: object
+      type: object
+      properties:
+        email:
+          description: the user email
+          required: true
+          example: foo@bar.com
+          type: string
+        username:
+          example: foo
+          description: username for new user
+          type: string
+        context:
+          description: context of authentification
+          type: object
           example:
-            email: foo@bar.com
-            username: foo
-            context:
-              currentUrl: localhost
+            currentUrl: localhost


### PR DESCRIPTION
It seems like Strapi prefers to have all schemas under schemas.

Before: 
![image](https://github.com/kucherenko/strapi-plugin-passwordless/assets/730511/ef5b2d54-946a-4ffc-af9a-9f578cbb65b7)

After 
![image](https://github.com/kucherenko/strapi-plugin-passwordless/assets/730511/7124a9fb-0bbe-457c-9010-068fd66e6000)
