### PR TITLE
fix(controllres): allow context of type object

### DIFF
--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -63,7 +63,7 @@ module.exports = {
     try {
       context = JSON.parse(token.context);
     } catch (e) {
-      context = {}
+      context = typeof token.context === "object" ? token.context : {};
     }
     ctx.send({
       jwt: jwtService.issue({id: user.id}),


### PR DESCRIPTION
Hi @kucherenko 
It's @douglasduteil again ;)

It seems like strapi (^4.11.5) already parse the context field returned by the service, resulting with an empty context on the login call due to `SyntaxError: "[object Object]" is not valid JSON`